### PR TITLE
Improve package/config validation

### DIFF
--- a/src/Model/EndPoint.php
+++ b/src/Model/EndPoint.php
@@ -51,4 +51,112 @@ class EndPoint
         return $this->packages;
     }
 
+    public function validate(): bool
+    {
+        // Check if repositories are correctly defined
+        $packageRepositories = $this->getConfigRepositories();
+        foreach ($packageRepositories as $packageRepository) {
+            if (!isset($packageRepository['name'])) {
+                throw new \Exception('Repository "' . $packageRepository['url'] . '" has no name');
+                return false;
+            }
+        }
+
+
+        // Check if packages are defined
+        if (count($this->packages) === 0) {
+            throw new \Exception('No packages defined');
+            return false;
+        }
+        $packages = $this->getPackages();
+        if ($packages === ['*']) {
+            return true;
+        }
+        // Validate that enabled packages have a corresponding repository
+        foreach ($packages as $package) {
+            $packageRepository = $this->getPackageRepositoryByName($package);
+            if (\is_null($packageRepository)) {
+                throw new \Exception('Package "' . $package . '" not found in repositories');
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function hasPackageByUrl(string $packageUrl): bool
+    {
+        $packageRepository = $this->getPackageRepositoryByUrl($packageUrl);
+        if (\is_null($packageRepository)) {
+//            $available = [];
+//            foreach ($this->getConfigRepositories() as $configRepository) {
+//                $available[] = $configRepository['url'];
+//            }
+//            echo 'repo "' . $packageRepository . '" not found, available: ' . \implode(', ', $available);
+            return false;
+        }
+
+        $packages = $this->getPackages();
+        if ($packages === ['*']) {
+            return true;
+        }
+
+        foreach ($packages as $package) {
+            if (isset($packageRepository['name']) && $packageRepository['name'] === $package) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function getPackageRepositoryByUrl(string $packageUrl): ?array
+    {
+        $configRepositories = $this->getConfigRepositories();
+        foreach ($configRepositories as $configRepository) {
+            if (isset($configRepository['url']) && \strtolower($configRepository['url']) === \strtolower($packageUrl)) {
+                return $configRepository;
+            }
+        }
+
+        return null;
+    }
+
+    public function getPackageRepositoryByName(string $packageName): ?array
+    {
+        $configRepositories = $this->getConfigRepositories();
+        foreach ($configRepositories as $configRepository) {
+            if (isset($configRepository['name']) && \strtolower($configRepository['name']) === \strtolower($packageName)) {
+                return $configRepository;
+            }
+        }
+
+        return null;
+    }
+
+
+    private $configFileContent = null;
+
+    private function getConfigRepositories(): array
+    {
+        $configFileContent = $this->getConfigFileContent();
+        return $configFileContent['repositories'];
+    }
+
+    private function getConfigFileContent(): array
+    {
+        if (\is_null($this->configFileContent)) {
+
+            $rawConfigFileContent = file_get_contents($this->configFile);
+            if ($rawConfigFileContent === false) {
+                throw new \Error('Unable to read config file content');
+            }
+            $configFileContent = json_decode($rawConfigFileContent, true);
+            if ($configFileContent === null) {
+                throw new \Error('Unable to read config file content');
+            }
+            $this->configFileContent = $configFileContent;
+        }
+        return $this->configFileContent;
+    }
+
 }


### PR DESCRIPTION
- when generating a single repository url, only generate endpoint for which the package is enabled
- validate the repositories and package configuration files
- validate that enabled packages are available in the repositories